### PR TITLE
New Workflow to CleanUp Plugins on PR Close

### DIFF
--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,0 +1,35 @@
+name: Cleanup PR Plugins
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install & Configure SquaredUp CLI
+        env:
+          SQUAREDUP_API_KEY: ${{ secrets.SQUAREDUP_API_KEY }}
+        run: |
+          npm install -g @squaredup/cli
+          squaredup login --apiKey "$SQUAREDUP_API_KEY"
+
+      - name: Delete PR plugins
+        run: |
+          pr_number="${{ github.event.pull_request.number }}"
+          echo "Looking for plugins deployed by PR #${pr_number}..."
+
+          plugins=$(squaredup list --json)
+          matches=$(echo "$plugins" | jq -r --arg pr "-${pr_number}" '.[] | select(.displayName | endswith($pr)) | .id')
+
+          if [ -z "$matches" ]; then
+            echo "No plugins found for PR #${pr_number}."
+            exit 0
+          fi
+
+          while IFS= read -r id; do
+            name=$(echo "$plugins" | jq -r --arg id "$id" '.[] | select(.id == $id) | .displayName')
+            echo "Deleting '${name}' (${id})..."
+            squaredup delete "${id}"
+          done <<< "$matches"


### PR DESCRIPTION
<!--
  Use this PR template only for changes that do *not* introduce or a change a plugin.
-->

## 📋 Summary
- Adds a new workflow to cleanup plugins deployed from PR when PR is closed

---

## 🔍 Scope of change

~- [ ] Documentation only~
~- [ ] Repository metadata or configuration~
- [x] CI / automation
~- [ ] Other (please describe):~

---

## 📚 Checklist

- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
