### PR TITLE
Add configValidation to DattoRMM plugin

### DIFF
--- a/plugins/DattoRMM/v1/configValidation.json
+++ b/plugins/DattoRMM/v1/configValidation.json
@@ -1,0 +1,11 @@
+{
+    "steps": [
+        {
+            "displayName": "Datto RMM connection",
+            "dataStream": { "name": "importSites", "timeframe": "none" },
+            "success": "Successfully connected to Datto RMM",
+            "error": "Cannot connect to Datto RMM — check your Base URL, API Key and API Secret",
+            "required": true
+        }
+    ]
+}

--- a/plugins/DattoRMM/v1/metadata.json
+++ b/plugins/DattoRMM/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "datto-rmm",
     "displayName": "Datto RMM",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": {
         "name": "@TimWheeler-SQUP",
         "type": "community"


### PR DESCRIPTION
## 📋 Summary

Adds a `configValidation.json` to the DattoRMM plugin so users get a connection test step during plugin setup. It validates the Base URL, API Key, and API Secret by exercising the existing `importSites` data stream (calls `api/v2/account/sites`).

---

## 🔗 Related issue(s)

---

## 🧩 Plugin details

- **Plugin name**: Datto RMM
- **Type of change**:
  - [ ] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [ ] Documentation / metadata / logo
  - [x] Other (please describe): Adds configValidation step

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

---

## 📚 Documentation

- [x] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)