### PR TITLE
fix: drop offline_access scope from NinjaOne OAuth, add configValidation

### DIFF
--- a/plugins/NinjaOne/v1/configValidation.json
+++ b/plugins/NinjaOne/v1/configValidation.json
@@ -4,7 +4,7 @@
             "displayName": "NinjaOne connection",
             "dataStream": { "name": "organizations" },
             "success": "Successfully connected to NinjaOne",
-            "error": "Cannot connect to NinjaOne — verify your Region, Client ID, and Client Secret, and that the API client has Client Credentials as an allowed grant type and the Monitoring, Management, and Control scopes enabled.",
+            "error": "Cannot connect to NinjaOne — verify your Region, Client ID, and Client Secret, and that the client app is generated as 'API Services' and the Monitoring, Management, and Control scopes enabled.",
             "required": true
         }
     ]

--- a/plugins/NinjaOne/v1/configValidation.json
+++ b/plugins/NinjaOne/v1/configValidation.json
@@ -1,0 +1,11 @@
+{
+    "steps": [
+        {
+            "displayName": "NinjaOne connection",
+            "dataStream": { "name": "organizations" },
+            "success": "Successfully connected to NinjaOne",
+            "error": "Cannot connect to NinjaOne — verify your Region, Client ID, and Client Secret, and that the API client has Client Credentials as an allowed grant type and the Monitoring, Management, and Control scopes enabled.",
+            "required": true
+        }
+    ]
+}

--- a/plugins/NinjaOne/v1/configValidation.json
+++ b/plugins/NinjaOne/v1/configValidation.json
@@ -4,7 +4,7 @@
             "displayName": "NinjaOne connection",
             "dataStream": { "name": "organizations" },
             "success": "Successfully connected to NinjaOne",
-            "error": "Cannot connect to NinjaOne — verify your Region, Client ID, and Client Secret, and that the client app is generated as 'API Services' and the Monitoring, Management, and Control scopes enabled.",
+            "error": "Cannot connect to NinjaOne — verify your Region, Client ID, and Client Secret, and ensure the client app is type 'API Services' with Monitoring, Management, and Control scopes enabled.",
             "required": true
         }
     ]

--- a/plugins/NinjaOne/v1/docs/README.md
+++ b/plugins/NinjaOne/v1/docs/README.md
@@ -4,17 +4,18 @@ To use this data source, you will need to create OAuth2 API credentials in your 
 
 ## Create NinjaOne API Credentials
 
-1. Log in to your NinjaOne portal
-2. Navigate to **Administration** > **API** > **Add Application**
-3. Configure the application:
-    - **Application Name**: Enter a descriptive name (e.g., "SquaredUp Integration")
-    - **Allowed Grant Types**: Ensure "Client Credentials" is enabled. "Refresh token" is not required and can be left disabled.
-    - **Scopes**: Select the following scopes:
-        - `Monitoring` - Required for device monitoring data
-        - `Management` - Required for management operations
-        - `Control` - Required for control operations
-4. Click **Create Application**
-5. Copy the **Client ID** and **Client Secret** - you will need these when configuring the plugin in SquaredUp
+1. Log in to your NinjaOne portal.
+2. Navigate to **Administration** > **Apps** > **API** and click **Add**.
+3. When prompted to choose an **Application Platform**, select **API Services**. This is what enables the Client Credentials grant type the plugin uses — **there is no separate "Client Credentials" checkbox to tick on the next screen.**
+4. On the **Client app** screen, fill in:
+    - **Name**: A descriptive name (e.g., "SquaredUp Integration").
+    - **Redirect URIs**: `https://app.squaredup.com/settings/pluginsoauth2`
+    - **Scopes**: Tick all three:
+        - `Monitoring` — required for device monitoring data
+        - `Management` — required for management operations
+        - `Control` — required for control operations
+    - **Allowed grant types**: `Refresh token` is **not** required by the plugin and can be left unticked.
+5. Save the application. NinjaOne will then show the **Client ID** and **Client Secret** — copy both, as you'll need them when configuring the plugin in SquaredUp. (The Client Secret is only shown once on creation; if you lose it, use **Generate new secret** to issue a new one.)
 
 ## Configure the Plugin in SquaredUp
 
@@ -76,7 +77,7 @@ This plugin provides the following data streams for monitoring your NinjaOne env
 
 ## Troubleshooting
 
-**Authentication Failed**: Ensure your Client ID and Client Secret are correct and that "Client Credentials" is enabled as an allowed grant type in your NinjaOne API application.
+**Authentication Failed**: Verify your Client ID and Client Secret are correct. Also check that your NinjaOne client app was created with the **API Services** application platform — this is what makes Client Credentials the active grant type. There is no separate "Client Credentials" checkbox in the client app screen; if you picked a different platform (e.g. Web app), the OAuth token request will fail.
 
 **No Data Returned**: Verify that the selected API Region matches your NinjaOne instance region.
 

--- a/plugins/NinjaOne/v1/docs/README.md
+++ b/plugins/NinjaOne/v1/docs/README.md
@@ -8,12 +8,11 @@ To use this data source, you will need to create OAuth2 API credentials in your 
 2. Navigate to **Administration** > **API** > **Add Application**
 3. Configure the application:
     - **Application Name**: Enter a descriptive name (e.g., "SquaredUp Integration")
-    - **Allowed Grant Types**: Ensure "Client Credentials" is enabled
+    - **Allowed Grant Types**: Ensure "Client Credentials" is enabled. "Refresh token" is not required and can be left disabled.
     - **Scopes**: Select the following scopes:
-        - `monitoring` - Required for device monitoring data
-        - `management` - Required for management operations
-        - `control` - Required for control operations
-        - `offline_access` - Required for refresh tokens
+        - `Monitoring` - Required for device monitoring data
+        - `Management` - Required for management operations
+        - `Control` - Required for control operations
 4. Click **Create Application**
 5. Copy the **Client ID** and **Client Secret** - you will need these when configuring the plugin in SquaredUp
 
@@ -81,7 +80,7 @@ This plugin provides the following data streams for monitoring your NinjaOne env
 
 **No Data Returned**: Verify that the selected API Region matches your NinjaOne instance region.
 
-**Insufficient Permissions**: Ensure the API application has all required scopes (`monitoring`, `management`, `control`, `offline_access`).
+**Insufficient Permissions**: Ensure the API application has all required scopes (`Monitoring`, `Management`, `Control`).
 
 ## Additional Resources
 

--- a/plugins/NinjaOne/v1/metadata.json
+++ b/plugins/NinjaOne/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "ninja-one",
     "displayName": "NinjaOne",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"
@@ -23,7 +23,7 @@
             "oauth2ClientSecret": "{{clientSecret}}",
             "oauth2TokenUrl": "{{apiBaseUrl}}/oauth/token",
             "oauth2ClientSecretLocationDuringAuth": "body",
-            "oauth2Scope": "monitoring management control offline_access"
+            "oauth2Scope": "monitoring management control"
         }
     },
     "links": [

--- a/plugins/NinjaOne/v1/ui.json
+++ b/plugins/NinjaOne/v1/ui.json
@@ -40,11 +40,11 @@
     {
         "type": "password",
         "name": "clientSecret",
-        "label": "Client Secret",
-        "help": "Enter the Client Secret from your NinjaOne API credentials",
+        "label": "Client secret",
+        "help": "Enter the Client secret from your NinjaOne API credentials",
         "validation": {
             "required": true
         },
-        "placeholder": "Enter your Client Secret"
+        "placeholder": "Enter your Client secret"
     }
 ]

--- a/plugins/NinjaOne/v1/ui.json
+++ b/plugins/NinjaOne/v1/ui.json
@@ -35,7 +35,7 @@
         "validation": {
             "required": true
         },
-        "placeholder": "Enter your Client ID"
+        "placeholder": "Enter a Client ID"
     },
     {
         "type": "password",
@@ -45,6 +45,6 @@
         "validation": {
             "required": true
         },
-        "placeholder": "Enter your Client secret"
+        "placeholder": "Enter a Client secret"
     }
 ]


### PR DESCRIPTION
## 📋 Summary

A SquaredUp customer hit `Data source request failed: Request to https://eu-api.ninjarmm.com/oauth/token failed with status 400` when adding the NinjaOne plugin against the EU region. The same plugin works in Canada.

Root cause: the plugin's OAuth token request asks for `offline_access` in the scope string. `offline_access` is for issuing refresh tokens (authorization_code flow); the `client_credentials` flow this plugin uses never issues a refresh token, so the scope is a no-op. NinjaOne's EU OAuth server rejects the unused scope as `invalid_scope`/400; CA tolerates it — same code, different regional behaviour.

Changes:
- `metadata.json` — drop `offline_access` from `oauth2Scope`; bump `1.1.9 → 1.1.10`.
- `docs/README.md` — align scope list and troubleshooting with NinjaOne's actual UI (Monitoring, Management, Control) and note that the "Refresh token" grant type is not required.
- `configValidation.json` *(new)* — uses SquaredUp's validation (same pattern as AutoTask, Checkly, Snowflake, UptimeRobot). Runs the `organizations` data stream at config-save time so credential/scope/region problems now surface with an actionable message before the data source is even accepted, instead of an opaque 4xx during later queries.

## 🔗 Related issue(s)

<!-- link the customer report if there's one -->

## 🧩 Plugin details

- **Plugin name**: NinjaOne
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [x] Documentation / metadata / logo
  - [ ] Other

## ⚠️ Breaking changes

- [x] No

The fix removes a scope the plugin never used. Customers who enabled the "Refresh token" grant type as a workaround can leave it on or disable it — the plugin won't request a refresh token either way.

## 📚 Documentation

- [x] Documentation updated

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the Code of Conduct