### PR TITLE
mark ticketBoards import step as optional

### DIFF
--- a/plugins/NinjaOne/v1/indexDefinitions/default.json
+++ b/plugins/NinjaOne/v1/indexDefinitions/default.json
@@ -56,6 +56,7 @@
                 "name": "ticketBoards"
             },
             "timeframe": "none",
+            "optional": true,
             "objectMapping": {
                 "id": "id",
                 "name": "name",

--- a/plugins/NinjaOne/v1/metadata.json
+++ b/plugins/NinjaOne/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "ninja-one",
     "displayName": "NinjaOne",
-    "version": "1.1.10",
+    "version": "1.1.11",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"


### PR DESCRIPTION
## 📋 Summary

Fixes a 500 at import time for NinjaOne tenants that don't have the
Ticketing module enabled. The `/v2/ticketing/trigger/boards` endpoint
returns "Ninja Ticketing Integration is not enabled" for these tenants,
which was failing the entire import.

Marks the `ticketBoards` import step as `optional: true`, so the step
finalises with a warning status instead of failing the whole import
when the read errors.

---

## 🔗 Related issue(s)

<!-- add ticket link if there is one -->

---

## 🧩 Plugin details

- **Plugin name**: NinjaOne
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [ ] Documentation / metadata / logo
  - [ ] Other (please describe):

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

---

## 📚 Documentation

- [ ] Documentation updated
- [x] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)