### PR TITLE
add us2 region for NinjaOne

### DIFF
--- a/plugins/NinjaOne/v1/docs/README.md
+++ b/plugins/NinjaOne/v1/docs/README.md
@@ -21,7 +21,7 @@ To use this data source, you will need to create OAuth2 API credentials in your 
 
 When adding the NinjaOne data source in SquaredUp, you will need to provide:
 
-1. **Region**: Select your NinjaOne instance region (US, EU, Canada, or OC). The API URL will be automatically configured based on your selection.
+1. **Region**: Select your NinjaOne instance region (US, US2, EU, Canada, or OC). The API URL will be automatically configured based on your selection.
 
 2. **Client ID**: Paste the Client ID from your NinjaOne API application
 

--- a/plugins/NinjaOne/v1/metadata.json
+++ b/plugins/NinjaOne/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "ninja-one",
     "displayName": "NinjaOne",
-    "version": "1.1.11",
+    "version": "1.1.12",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"

--- a/plugins/NinjaOne/v1/ui.json
+++ b/plugins/NinjaOne/v1/ui.json
@@ -11,7 +11,7 @@
                 "label": "US"
             },
             {
-                "value": "https://us2-api.ninjarmm.com",
+                "value": "https://api.us2.ninjarmm.com",
                 "label": "US2"
             },
             {

--- a/plugins/NinjaOne/v1/ui.json
+++ b/plugins/NinjaOne/v1/ui.json
@@ -11,6 +11,10 @@
                 "label": "US"
             },
             {
+                "value": "https://us2-api.ninjarmm.com",
+                "label": "US2"
+            },
+            {
                 "value": "https://eu-api.ninjarmm.com",
                 "label": "EU"
             },


### PR DESCRIPTION
## 📋 Summary

Adds the **US2** region as a selectable option for the NinjaOne plugin. A customer whose NinjaOne instance is hosted in the US2 region was unable to connect via SquaredUp, as only US, EU, Canada, and OC regions were previously available. This PR adds the US2 API base URL (`https://us2-api.ninjarmm.com`) to the region selector.

---

## 🔗 Related issue(s)

- Relates to PLUG-4644

---

## 🧩 Plugin details

- **Plugin name**: NinjaOne
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [ ] Documentation / metadata / logo

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

---

## 📚 Documentation

- [ ] Documentation updated
- [x] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
