### PR TITLE
Add paging support to Rootly- incidents datastream

### DIFF
--- a/plugins/Rootly/v1/dataStreams/incidents.json
+++ b/plugins/Rootly/v1/dataStreams/incidents.json
@@ -2,6 +2,26 @@
     "name": "incidents",
     "config": {
         "httpMethod": "get",
+        "paging": {
+            "mode": "offset",
+            "pageSize": {
+                "realm": "queryArg",
+                "path": "page[size]",
+                "value": "200"
+            },
+            "offset": {
+                "rowCountIn": {
+                    "realm": "payloadArraySize",
+                    "path": "data"
+                },
+                "mode": "page",
+                "base": "1"
+            },
+            "out": {
+                "realm": "queryArg",
+                "path": "page[number]"
+            }
+        },
         "expandInnerObjects": true,
         "endpointPath": "incidents",
         "getArgs": [
@@ -12,14 +32,6 @@
             {
                 "key": "filter[{{timestampField}}][lte]",
                 "value": "{{{timeframe.end}}}"
-            },
-            {
-                "key": "page[number]",
-                "value": "1"
-            },
-            {
-                "key": "page[size]",
-                "value": "100"
             }
         ],
         "postRequestScript": "incidents.js",

--- a/plugins/Rootly/v1/dataStreams/incidents.json
+++ b/plugins/Rootly/v1/dataStreams/incidents.json
@@ -1,5 +1,6 @@
 {
     "name": "incidents",
+    "tags": ["Incidents"],
     "config": {
         "httpMethod": "get",
         "paging": {

--- a/plugins/Rootly/v1/metadata.json
+++ b/plugins/Rootly/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "rootly",
     "displayName": "Rootly",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": {
         "name": "@noorulkhan-n",
         "type": "community"

--- a/plugins/Rootly/v1/metadata.json
+++ b/plugins/Rootly/v1/metadata.json
@@ -23,7 +23,6 @@
                 }
             ],
             "queryArgs": [],
-            "modules": [],
             "authMode": "none",
             "baseUrl": "https://api.rootly.com/v1/"
         }


### PR DESCRIPTION
## 📋 Summary

- Added offset-based paging support for the incidents datastream.
- Configured page size and offset handling to retrieve all records across multiple pages.
- Ensures incident imports continue correctly when API responses exceed a single page.

## 🧩 Plugin details

- Plugin name: <plugin name>

- Type of change:
  - [ ] Bug fix
  - [ ] New datastream
  - [x] Enhancement to existing datastream
  - [ ] Performance improvement
  - [ ] Documentation / metadata / logo
  - [ ] Other (please describe)

## ⚠️ Breaking changes

- [x] No
- [ ] Yes (please describe)

## 📚 Documentation

- [x] No documentation changes needed
- [ ] Documentation updated

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the Code of Conduct