### PR TITLE
PLUG-4656: MicrosoftDefender - Fix Device Import not working

### DIFF
--- a/plugins/MicrosoftDefender/v1/dataStreams/listDevices.json
+++ b/plugins/MicrosoftDefender/v1/dataStreams/listDevices.json
@@ -13,7 +13,7 @@
     "expandInnerObjects": true,
     "endpointPath": "runHuntingQuery",
     "postBody": {
-      "Query": "DeviceInfo | summarize arg_max(Timestamp, *) by DeviceId | where DeviceName != \"\""
+      "Query": "DeviceInfo | where isnotempty(DeviceName) | project Timestamp, DeviceId, DeviceName | summarize arg_max(Timestamp, *) by DeviceId"
     },
     "pathToData": "results",
     "getArgs": [],

--- a/plugins/MicrosoftDefender/v1/indexDefinitions/default.json
+++ b/plugins/MicrosoftDefender/v1/indexDefinitions/default.json
@@ -11,15 +11,7 @@
                 "name": "DeviceName",
                 "type": {
                     "value": "Device"
-                },
-                "properties": [
-                    "OSPlatform",
-                    "OSProcessor",
-                    "OSVersion",
-                    "PublicIP",
-                    "OSBuild",
-                    "OSArchitecture"
-                ]
+                }
             }
         }
     ]

--- a/plugins/MicrosoftDefender/v1/metadata.json
+++ b/plugins/MicrosoftDefender/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "microsoft-defender",
     "displayName": "Microsoft Defender",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"


### PR DESCRIPTION
## 📋 Summary
<!--
  Briefly describe what this PR does and why it's needed.

  > Examples:  
  > Adds a new `CPU Usage` datastream to expose CPU information for hosts
  > Fixes an issue when authenticating with OAuth
-->

- PR to fix issues experienced by Evida & other customers with Device imports. 
- Main change is the ordering of operations to improve performance (likely minimal but there) and a change to the way we check for invalid rows. Evida are having issues with this, so the potential fix is to move to an `isnotempty` check over `!=` to exclude null `DeviceNames`
- Removed redundant columns from Device objects as to speed up the query.
## 🧩 Plugin details

- **Plugin name**:
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [x] Performance improvement
  - [ ] Documentation / metadata / logo
  - [ ] Other (please describe):

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

If yes, describe:
- What breaks
- Who is impacted
- Any migration steps

---

## 📚 Documentation

- [ ] Documentation updated
- [x] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
