### PR TITLE
Fix: Region updates and URL changes for NinjaOne plugin

### DIFF
--- a/plugins/NinjaOne/v1/metadata.json
+++ b/plugins/NinjaOne/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "ninja-one",
     "displayName": "NinjaOne",
-    "version": "1.1.13",
+    "version": "1.1.14",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"

--- a/plugins/NinjaOne/v1/metadata.json
+++ b/plugins/NinjaOne/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "ninja-one",
     "displayName": "NinjaOne",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"

--- a/plugins/NinjaOne/v1/ui.json
+++ b/plugins/NinjaOne/v1/ui.json
@@ -15,7 +15,7 @@
                 "label": "US2"
             },
             {
-                "value": "https://eu-api.ninjarmm.com",
+                "value": "https://eu.ninjarmm.com",
                 "label": "EU"
             },
             {

--- a/plugins/NinjaOne/v1/ui.json
+++ b/plugins/NinjaOne/v1/ui.json
@@ -4,14 +4,14 @@
         "name": "apiBaseUrl",
         "label": "Region",
         "help": "Select your NinjaOne instance region",
-        "defaultValue": "https://ca-api.ninjarmm.com",
+        "defaultValue": "https://ca.ninjarmm.com",
         "options": [
             {
-                "value": "https://api.ninjarmm.com",
+                "value": "https://app.ninjarmm.com",
                 "label": "US"
             },
             {
-                "value": "https://api.us2.ninjarmm.com",
+                "value": "https://us2.ninjarmm.com",
                 "label": "US2"
             },
             {
@@ -19,11 +19,11 @@
                 "label": "EU"
             },
             {
-                "value": "https://ca-api.ninjarmm.com",
+                "value": "https://ca.ninjarmm.com",
                 "label": "Canada"
             },
             {
-                "value": "https://oc-api.ninjarmm.com",
+                "value": "https://oc.ninjarmm.com",
                 "label": "OC"
             }
         ],


### PR DESCRIPTION
## 📋 Summary
<!--
  Briefly describe what this PR does and why it's needed.

  > Examples:  
  > Adds a new `CPU Usage` datastream to expose CPU information for hosts
  > Fixes an issue when authenticating with OAuth
-->
Quite a simple region change for the EU region for the NinjaOne plugin. This does not break existing EU region customers as the new/changed URL resolves to the same API. This change is needed though as some NinjaOne customers do require eu.ninjarmm.com. The existing eu-api.ninjarmm.com URL that the plugin uses is an alias that seemingly not all customers can use.

I have also updated the other regions so they use this newer URL format from NinJaOne. Although we do not have every region to test against, I have verified that any updated URLs do resolve to the same IP addresses as the previous, so they hit the same APIs which wont break anything for existing users.

---

## 🔗 Related issue(s)
<!--
  Link any related issues or discussions.

  - Closes #
  - Relates to #
-->
https://squaredup-eng.atlassian.net/browse/PLUG-4662

---

## 🧩 Plugin details

- **Plugin name**:
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [ ] Documentation / metadata / logo
  - [ ] Other (please describe):

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

If yes, describe:
- What breaks
- Who is impacted
- Any migration steps

---

## 📚 Documentation

- [ ] Documentation updated
- [x] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the NinjaOne API base URL settings to use the latest endpoint hostnames (including Canada and EU), ensuring requests go to the correct regional services.
* **Chores**
  * Bumped the NinjaOne plugin version to **1.1.14**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->