### PR TITLE
PLUG-4678: Microsoft Defender: Split Device import into segments

### DIFF
--- a/plugins/MicrosoftDefender/v1/dataStreams/listDevices.json
+++ b/plugins/MicrosoftDefender/v1/dataStreams/listDevices.json
@@ -13,12 +13,15 @@
     "expandInnerObjects": true,
     "endpointPath": "runHuntingQuery",
     "postBody": {
-      "Query": "DeviceInfo | where isnotempty(DeviceName) | project Timestamp, DeviceId, DeviceName | summarize arg_max(Timestamp, *) by DeviceId"
+      "Query": "DeviceInfo | where isnotempty(DeviceName) and hash(DeviceId, 4) == {{shardIndex}} | project Timestamp, DeviceId, DeviceName | summarize arg_max(Timestamp, *) by DeviceId"
     },
     "pathToData": "results",
     "getArgs": [],
     "headers": []
   },
+  "ui": [
+    { "name": "shardIndex", "label": "Shard Index", "type": "text", "defaultValue": "0" }
+  ],
   "providesPluginDiagnostics": true,
   "manualConfigApply": true,
   "timeframes": false,

--- a/plugins/MicrosoftDefender/v1/indexDefinitions/default.json
+++ b/plugins/MicrosoftDefender/v1/indexDefinitions/default.json
@@ -1,9 +1,55 @@
 {
     "steps": [
         {
-            "name": "Import Devices",
+            "name": "Import Devices (1)",
             "dataStream": {
-                "name": "listDevices"
+                "name": "listDevices",
+                "config": { "shardIndex": "0" }
+            },
+            "timeframe": "none",
+            "objectMapping": {
+                "id": "DeviceId",
+                "name": "DeviceName",
+                "type": {
+                    "value": "Device"
+                }
+            }
+        },
+        {
+            "name": "Import Devices (2)",
+            "dataStream": {
+                "name": "listDevices",
+                "config": { "shardIndex": "1" }
+            },
+            "timeframe": "none",
+            "objectMapping": {
+                "id": "DeviceId",
+                "name": "DeviceName",
+                "type": {
+                    "value": "Device"
+                }
+            }
+        },
+        {
+            "name": "Import Devices (3)",
+            "dataStream": {
+                "name": "listDevices",
+                "config": { "shardIndex": "2" }
+            },
+            "timeframe": "none",
+            "objectMapping": {
+                "id": "DeviceId",
+                "name": "DeviceName",
+                "type": {
+                    "value": "Device"
+                }
+            }
+        },
+        {
+            "name": "Import Devices (4)",
+            "dataStream": {
+                "name": "listDevices",
+                "config": { "shardIndex": "3" }
             },
             "timeframe": "none",
             "objectMapping": {

--- a/plugins/MicrosoftDefender/v1/metadata.json
+++ b/plugins/MicrosoftDefender/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "microsoft-defender",
     "displayName": "Microsoft Defender",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"


### PR DESCRIPTION
## 📋 Summary
<!--
  Briefly describe what this PR does and why it's needed.

  > Examples:  
  > Adds a new `CPU Usage` datastream to expose CPU information for hosts
  > Fixes an issue when authenticating with OAuth
-->
- This PR splits the device imports for Defender into four seperate steps, in order to fix large payload sizes (Davies Group importing 6000+ devices) exceeding the 6MB limit. Since we use the [Advanced Hunting](https://learn.microsoft.com/en-us/graph/api/security-security-runhuntingquery?view=graph-rest-1.0&tabs=http) API to fetch devices, no pagination is supported. 
- The proposal is to split devices into four buckets based on the `hash()` function- no devices should be dropped, the only risk is running into the same issue where a bucket exceeds 6MB, but since device IDS are split _mostly_ evenly, this is unlikely (would require ~24MB of data)
- Testing using our environment gave a pretty even split- this should work the same even with a scaled environment.

Example:
<img width="347" height="177" alt="image" src="https://github.com/user-attachments/assets/58b92fd4-2c8e-4de5-942e-0199982fb043" />

---
## 🧩 Plugin details

- **Plugin name**:
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [x] Enhancement to existing datastream
  - [x] Performance improvement
  - [ ] Documentation / metadata / logo
  - [ ] Other (please describe):

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

---

## 📚 Documentation

- [ ] Documentation updated
- [x] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
