### PR TITLE
Add note on using defaultValue with a json code field

### DIFF
--- a/.claude/skills/build-plugin/references/ui.md
+++ b/.claude/skills/build-plugin/references/ui.md
@@ -260,6 +260,12 @@ Choosing between them: use **`radio`** when each option reads best on its own li
 { "type": "code", "name": "body", "label": "Request Body", "language": "json" }
 ```
 
+> ⚠️ When `language` is `json`, `defaultValue` must be a JSON object, not a string — the editor calls `JSON.stringify` on it. A string `defaultValue` renders as a quoted, escaped blob instead of formatted JSON.
+>
+> ```json
+> { "type": "code", "name": "body", "language": "json", "defaultValue": { "key": "value" } }
+> ```
+
 **`script`** — inline JavaScript editor:
 
 ```json


### PR DESCRIPTION
<!--
  Use this PR template only for changes that do *not* introduce or a change a plugin.
-->

## 📋 Summary

As Dave noted, the agent can sometimes use a `string` defaultValue for a code input, which causes issues with the `json` language option. It double encoding the object string, rather than rendering as a JSON object in the editor.


---

## 🔍 Scope of change

- [x] Documentation only
- [ ] Repository metadata or configuration
- [ ] CI / automation
- [ ] Other (please describe):

---

## 📚 Checklist

- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a warning explaining that JSON editor defaults must be provided as an object, not a string.
  * Included a clearer example showing the correct JSON `defaultValue` format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->