### PR TITLE
PLUG-4682: Fix extra-time/penalty results in World Cup match data streams

### DIFF
--- a/plugins/WorldCup2026/v1/dataStreams/scripts/knockout.js
+++ b/plugins/WorldCup2026/v1/dataStreams/scripts/knockout.js
@@ -12,8 +12,13 @@ var stageMap = {
 result = matches.filter(function(m) { return !m.group; }).map(function(m) {
     var score = '-';
     var status = 'Upcoming';
-    if (m.score && m.score.ft) {
-        score = m.score.ft[0] + '-' + m.score.ft[1];
+    if (m.score && (m.score.et || m.score.ft)) {
+        // Prefer the score after extra time; fall back to the 90-minute (ft) score.
+        var base = m.score.et || m.score.ft;
+        score = base[0] + '-' + base[1];
+        if (m.score.p) {
+            score += ' (' + m.score.p[0] + '-' + m.score.p[1] + ' pens)';
+        }
         status = 'Finished';
     }
 

--- a/plugins/WorldCup2026/v1/dataStreams/scripts/last-match.js
+++ b/plugins/WorldCup2026/v1/dataStreams/scripts/last-match.js
@@ -25,15 +25,27 @@ if (played.length === 0) {
     var last = played[0];
     var isHome = last.team1 === teamName;
     var opponent = isHome ? last.team2 : last.team1;
-    var myScore = isHome ? last.score.ft[0] : last.score.ft[1];
-    var oppScore = isHome ? last.score.ft[1] : last.score.ft[0];
-    var matchResult = myScore > oppScore ? 'Win' : myScore < oppScore ? 'Loss' : 'Draw';
+    // Prefer the score after extra time; fall back to the 90-minute (ft) score.
+    var base = last.score.et || last.score.ft;
+    var myScore = isHome ? base[0] : base[1];
+    var oppScore = isHome ? base[1] : base[0];
+    var score = myScore + '-' + oppScore;
+    var matchResult;
+    if (last.score.p) {
+        // Match went to a penalty shootout — the winner is decided on penalties.
+        var myPens = isHome ? last.score.p[0] : last.score.p[1];
+        var oppPens = isHome ? last.score.p[1] : last.score.p[0];
+        score += ' (' + myPens + '-' + oppPens + ' pens)';
+        matchResult = myPens > oppPens ? 'Win' : 'Loss';
+    } else {
+        matchResult = myScore > oppScore ? 'Win' : myScore < oppScore ? 'Loss' : 'Draw';
+    }
 
     result = [{
         date: last.date,
         home_away: isHome ? 'Home' : 'Away',
         opponent: opponent,
-        score: myScore + '-' + oppScore,
+        score: score,
         result: matchResult,
         stage: last.group ? 'Group Stage' : (knockoutStageMap[last.round] || last.round),
         sourceId: sourceId

--- a/plugins/WorldCup2026/v1/dataStreams/scripts/matches.js
+++ b/plugins/WorldCup2026/v1/dataStreams/scripts/matches.js
@@ -21,8 +21,13 @@ filtered.sort(function(a, b) {
 result = filtered.map(function(m) {
     var score = '-';
     var status = 'Upcoming';
-    if (m.score && m.score.ft) {
-        score = m.score.ft[0] + '-' + m.score.ft[1];
+    if (m.score && (m.score.et || m.score.ft)) {
+        // Prefer the score after extra time; fall back to the 90-minute (ft) score.
+        var base = m.score.et || m.score.ft;
+        score = base[0] + '-' + base[1];
+        if (m.score.p) {
+            score += ' (' + m.score.p[0] + '-' + m.score.p[1] + ' pens)';
+        }
         status = 'Finished';
     }
 

--- a/plugins/WorldCup2026/v1/metadata.json
+++ b/plugins/WorldCup2026/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "worldcup2026",
     "displayName": "FIFA World Cup 2026",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "author": {
         "name": "@TimWheeler-SQUP",
         "type": "community"


### PR DESCRIPTION
## 📋 Summary

The World Cup match data streams read only `score.ft` (the score after 90 minutes) from the openfootball feed. For knockout matches decided in **extra time** or on **penalties**, this shows the wrong result.

Most visible for England — e.g. the 2026 Quarter-final vs Norway (`{"ft":[1,1],"et":[1,2]}`) was shown as **1-1** and reported as a **Draw**, when England actually won **2-1** in extra time.

The fix updates the three knockout-capable scripts to prefer `score.et` over `score.ft`, and to append the penalty shootout result when present (e.g. `1-1 (4-3 pens)`). `last-match.js` now also decides Win/Loss/Draw from the shootout rather than the pre-shootout scoreline. Group-stage streams are unaffected (group games can't go to extra time/penalties). Plugin bumped `1.2.1 → 1.2.2`.

Verified by running the post-request scripts against the live 2026 feed and the completed 2022 feed (Argentina final `3-3 (4-2 pens)` / Win; France `3-3 (2-4 pens)` / Loss), and end-to-end via `squaredup test` against a deployed instance.

---

## 🔗 Related issue(s)

- [PLUG-4682](https://squaredup-eng.atlassian.net/browse/PLUG-4682)

---

## 🧩 Plugin details

- **Plugin name**: FIFA World Cup 2026 (`worldcup2026`)
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [ ] Documentation / metadata / logo
  - [ ] Other (please describe):

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

---

## 📚 Documentation

- [ ] Documentation updated
- [x] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Match scores now accurately reflect extra-time results when applicable.
  * Penalty shootout scores are displayed alongside the final match score.
  * Match outcomes correctly identify the shootout winner.

* **Chores**
  * Updated the World Cup 2026 plugin version to 1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->