### PR TITLE
Recommend script files for errorHandling scripts in the build-plugin skill

### DIFF
--- a/.claude/skills/build-plugin/SKILL.md
+++ b/.claude/skills/build-plugin/SKILL.md
@@ -188,6 +188,8 @@ my-plugin/
       myStream.json
       scripts/
         myScript.js
+        errorHandling/
+          myStream.js          # errorHandling scripts referenced by path, like postRequestScript
     defaultContent/
       manifest.json
       scopes.json

--- a/.claude/skills/build-plugin/references/data-streams.md
+++ b/.claude/skills/build-plugin/references/data-streams.md
@@ -479,6 +479,24 @@ The `paging` block in `config` controls how SquaredUp fetches multiple pages.
 "errorHandling": { "type": "script", "script": "result = response.status + ': ' + data.error;" }
 ```
 
+### Script files over inline scripts
+
+For anything beyond a trivial one-liner, don't inline the script in the JSON — reference a file, the same mechanism [`postRequestScript`](#post-request-scripts) uses. Place the file in `dataStreams/scripts/errorHandling/`, named after the stream's `name` field, and set `script` to its path relative to `dataStreams/scripts/` — **the `.js` extension is required** (a bare `.js` path with no newline is what marks the value as a file reference; deploy inlines the file's source, and an unresolvable reference is a validation error).
+
+Stream JSON (`dataStreams/incidents.json`):
+
+```json
+"errorHandling": { "type": "script", "script": "errorHandling/incidents.js" }
+```
+
+Script file (`dataStreams/scripts/errorHandling/incidents.js`) — multi-line source, and `{{ ... }}` expressions work exactly as they do inline:
+
+```javascript
+const apiMsg = data && (data.message || data.error);
+
+result = apiMsg || ('Request failed with HTTP ' + response.status);
+```
+
 ---
 
 ## pathToData
@@ -736,7 +754,7 @@ Scripts run after the HTTP response is received. Input is `data` (parsed JSON bo
 
 ### Wiring a script to a stream
 
-Set `postRequestScript` inside `config` to the script's filename — **the `.js` extension is required**. Name the file after the stream's `name` field and place it in `dataStreams/scripts/`.
+Set `postRequestScript` inside `config` to the script's filename — **the `.js` extension is required**. Name the file after the stream's `name` field and place it in `dataStreams/scripts/`. ([errorHandling scripts](#errorhandling) use the same file-reference mechanism, from the `errorHandling/` sub-folder.)
 
 Stream JSON (`dataStreams/incidents.json`):
 

--- a/.claude/skills/build-plugin/references/data-streams.md
+++ b/.claude/skills/build-plugin/references/data-streams.md
@@ -476,20 +476,14 @@ The `paging` block in `config` controls how SquaredUp fetches multiple pages.
 "errorHandling": { "type": "path", "realm": "payload", "path": "error.message" }
 
 // Custom script — access response (.status, .body) and data
-"errorHandling": { "type": "script", "script": "result = response.status + ': ' + data.error;" }
-```
-
-### Script files over inline scripts
-
-For anything beyond a trivial one-liner, don't inline the script in the JSON — reference a file, the same mechanism [`postRequestScript`](#post-request-scripts) uses. Place the file in `dataStreams/scripts/errorHandling/`, named after the stream's `name` field, and set `script` to its path relative to `dataStreams/scripts/` — **the `.js` extension is required** (a bare `.js` path with no newline is what marks the value as a file reference; deploy inlines the file's source, and an unresolvable reference is a validation error).
-
-Stream JSON (`dataStreams/incidents.json`):
-
-```json
 "errorHandling": { "type": "script", "script": "errorHandling/incidents.js" }
 ```
 
-Script file (`dataStreams/scripts/errorHandling/incidents.js`) — multi-line source, and `{{ ... }}` expressions work exactly as they do inline:
+### Script files
+
+Reference the script as a file — the same mechanism [`postRequestScript`](#post-request-scripts) uses. Place the file in `dataStreams/scripts/errorHandling/`, named after the stream's `name` field, and set `script` to its path relative to `dataStreams/scripts/` — **the `.js` extension is required** (a bare `.js` path with no newline is what marks the value as a file reference; deploy inlines the file's source, and an unresolvable reference is a validation error).
+
+Script file (`dataStreams/scripts/errorHandling/incidents.js`) — `{{ ... }}` expressions work in script files too:
 
 ```javascript
 const apiMsg = data && (data.message || data.error);


### PR DESCRIPTION
## 📋 Summary

The build-plugin skill only showed `errorHandling` scripts written inline in the stream JSON, which becomes unreadable beyond a one-liner. The deploy pipeline resolves `errorHandling.script` file references from `dataStreams/scripts/` using exactly the same mechanism as `postRequestScript` (it's one of the two registered `dataStreamScriptPaths`, and plugin export already writes to an `errorHandling/` sub-folder), so the skill now documents that form — and only that form, since script files are easier to review than inline JSON strings:

- The **errorHandling** section of `references/data-streams.md` shows the file-reference form as the way to write a script (`dataStreams/scripts/errorHandling/<streamName>.js`), with a "Script files" subsection covering the reference-resolution rules (bare `.js` path marks a reference, deploy inlines the source, unresolvable references fail validation, `{{ ... }}` expressions work in script files too) and a script-file example. No inline example remains.
- The post-request script wiring section cross-links the errorHandling equivalent.
- The scaffold folder layout in `SKILL.md` shows the `scripts/errorHandling/` sub-folder.

---

## 🔍 Scope of change

- [x] Documentation only
- [ ] Repository metadata or configuration
- [ ] CI / automation
- [ ] Other (please describe):

---

## 📚 Checklist

- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin scaffolding guidance to include the `errorHandling/` script directory.
  * Clarified that error-handling scripts should be referenced as files rather than inline code.
  * Added examples and guidance on script placement, file paths, and required `.js` extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->