### PR TITLE
Guide build-plugin on pre-request auth scripts

### DIFF
--- a/.claude/skills/build-plugin/SKILL.md
+++ b/.claude/skills/build-plugin/SKILL.md
@@ -3,7 +3,7 @@ name: build-plugin
 description: Guides building a SquaredUp low-code plugin for HTTP/REST APIs, from API exploration through deployment. Use when the user wants to integrate a service with SquaredUp, add a new data source, connect to a third-party tool, "pull data from", or "monitor" any service in SquaredUp.
 metadata:
     author: SquaredUp
-    version: "0.0.12"
+    version: "1.0.0"
 ---
 
 # Building a SquaredUp Low-Code Plugin
@@ -68,7 +68,7 @@ Before writing a single file, understand and explore the API. **Use `AskUserQues
     - **Time-range control** — does the endpoint accept a queryable time range at all (a `from`/`to`, `start`/`end`, or `period` parameter), or only return a fixed snapshot / current values?
     - **Data granularity** — when the endpoint _does_ accept a range, the finest interval it aggregates at: **per-event/raw**, **hourly**, **daily**, or **monthly**. Read it off the API docs (aggregation windows, `granularity`/`interval` params, the minimum queryable range).
 5. **Understand pagination** — Cursor/next-token, or offset/limit? Separate concern from response transformation.
-6. **Note the auth pattern** — API key in header, Bearer token, OAuth2, Basic auth, JWT Bearer (signed-JWT auth)? Determine from the docs.
+6. **Note the auth pattern** — API key in header, Bearer token, OAuth2, Basic auth, JWT Bearer (signed-JWT auth)? Determine from the docs. If the flow is custom — a token-exchange step or per-request signing no standard mode covers — plan a **pre-request script** ([metadata.md](references/metadata.md#pre-request-scripts-custom-auth-flows)).
 
 ---
 
@@ -180,6 +180,7 @@ my-plugin/
     icon.svg
     custom_types.json
     configValidation.json      # required for authenticated APIs; validates config on setup
+    preRequest.js # only when using a pre-request script (custom auth)
     docs/
       README.md                # REQUIRED: shown in-product when users add the plugin
     indexDefinitions/

--- a/.claude/skills/build-plugin/references/data-streams.md
+++ b/.claude/skills/build-plugin/references/data-streams.md
@@ -744,7 +744,7 @@ Replace a raw ID column with a human-readable property from a related indexed ob
 
 ## Post-request scripts
 
-Scripts run after the HTTP response is received. Input is `data` (parsed JSON body). Set `result` to an array of row objects.
+Scripts run after the HTTP response is received. Input is `data` (parsed JSON body). Set `result` to an array of row objects. (For a datasource-level script that runs _before_ every request — custom auth flows — see [Pre-request scripts](metadata.md#pre-request-scripts-custom-auth-flows) in metadata.md.)
 
 ### Wiring a script to a stream
 

--- a/.claude/skills/build-plugin/references/metadata.md
+++ b/.claude/skills/build-plugin/references/metadata.md
@@ -4,6 +4,7 @@
 
 - [metadata.json template and field notes](#metadatajson)
 - [Auth patterns](#auth-patterns)
+- [Pre-request scripts (custom auth flows)](#pre-request-scripts-custom-auth-flows)
 
 ---
 
@@ -193,3 +194,69 @@ Set exactly one of `jwtSecret` (HMAC algorithms) or `jwtPrivateKey` — a PEM-en
 ```
 
 `jwtPayload` and `jwtHeaders` are plain JSON objects; any string value can itself be a `{{ ... }}` expression, evaluated fresh on every request — this is how `iat`/`exp` stay current without any extra logic.
+
+---
+
+## Pre-request scripts (custom auth flows)
+
+> Requires WebAPI base plugin **1.8.0+**.
+
+Some APIs have an auth flow no `authMode` above can express — exchanging a long-lived credential for a short-lived access token via an auth endpoint, or signing each request (HMAC canonical-request signatures). For these, set a **pre-request script** in `base.config`: JavaScript that runs immediately before **every** HTTP request the plugin makes (all data streams, including import streams) and can rewrite the request's `url`, `headers`, and `body`.
+
+Exhaust the auth patterns above first — a pre-request script that only sets a static header is just a `headers` entry, and token refresh for OAuth2/JWT Bearer is already automatic.
+
+### Wiring
+
+In `base.config`:
+
+```json
+"scriptingVariables": [
+    { "key": "signedJwt", "value": "{{signedJwt}}" }
+],
+"preRequestScript": "preRequest/my-plugin.js"
+```
+
+- `scriptingVariables` — key/value secrets the script reads as `secrets.<key>`. Values support `{{fieldName}}` expressions referencing `ui.json` fields, same as `headers`. Values are encrypted at rest.
+- `preRequestScript` — a file reference relative to `dataStreams/scripts/`: put the script at `dataStreams/scripts/preRequest/my-plugin.js` (named after the plugin, `.js` extension required); it's inlined into the config at deploy time.
+- `scriptState` — never set this: it's a reserved config property where the platform persists the script's `state`, encrypted.
+
+### Script scope
+
+The script body runs inside an async function — top-level `await` works. `fetch` and `crypto.subtle` are available (for auth calls and HMAC/SHA signing).
+
+| Variable  | Mutable | Notes                                                                                                                                                                                 |
+| --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`     | Yes     | [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) instance of the full endpoint address about to be called                                                                  |
+| `method`  | No      | `"get"` or `"post"`                                                                                                                                                                     |
+| `headers` | Yes     | POJO of request headers — the usual thing a script mutates                                                                                                                              |
+| `body`    | Yes     | Request body (POST only)                                                                                                                                                                |
+| `state`   | Yes     | POJO persisted (encrypted) between requests — cache tokens here with an expiry. It can disappear at any time, so always re-derive when missing or expired, never assume it's populated |
+| `secrets` | No      | Values from `scriptingVariables`, by key                                                                                                                                                |
+| `api`     | No      | `api.report.warning(text)` / `api.report.error(text)`                                                                                                                                   |
+| `context` | No      | `dataSources[0]` (the plugin config, incl. `baseUrl`), `objects`, `timeframe`, `config` (the calling stream's config), `pagingContext`                                                  |
+
+### Example: token exchange with cached state
+
+The user supplies a pre-signed JWT (a `ui.json` field mapped via `scriptingVariables`); the script exchanges it for a short-lived access token and caches it in `state` until expiry:
+
+```javascript
+// dataStreams/scripts/preRequest/my-plugin.js
+const now = Date.now();
+if (typeof state?.token !== "string" || (state?.expiryTime ?? 0) <= now) {
+    const authUrl = `${context.dataSources[0].baseUrl.replace(/\/*$/, "")}/api/auth/authenticate`;
+    const resp = await fetch(authUrl, {
+        method: "post",
+        headers: { Accept: "application/json", Authorization: `Bearer ${secrets.signedJwt}` },
+    });
+    if (!resp.ok) {
+        api.report.error(`Failed to get token: ${resp.status} - ${resp.statusText}`);
+    }
+    const payload = await resp.json();
+    state = {
+        token: payload.tokens.access.token,
+        // refresh 1 minute early to be safe
+        expiryTime: now + payload.tokens.access.expirySeconds * 1000 - 60000,
+    };
+}
+headers["Authorization"] = `Bearer ${state.token}`;
+```

--- a/.claude/skills/build-plugin/references/metadata.md
+++ b/.claude/skills/build-plugin/references/metadata.md
@@ -211,11 +211,11 @@ In `base.config`:
 "scriptingVariables": [
     { "key": "signedJwt", "value": "{{signedJwt}}" }
 ],
-"preRequestScript": "preRequest/my-plugin.js"
+"preRequestScript": "preRequest.js"
 ```
 
 - `scriptingVariables` — key/value secrets the script reads as `secrets.<key>`. Values support `{{fieldName}}` expressions referencing `ui.json` fields, same as `headers`. Values are encrypted at rest.
-- `preRequestScript` — a file reference relative to `dataStreams/scripts/`: put the script at `dataStreams/scripts/preRequest/my-plugin.js` (named after the plugin, `.js` extension required); it's inlined into the config at deploy time.
+- `preRequestScript` — a file reference relative to the plugin's version root (unlike data-stream scripts, which live under `dataStreams/scripts/`): put the script at `<plugin>/v1/preRequest.js`; it's inlined into the config at deploy time. There's only ever one per plugin, so it doesn't need a per-plugin filename or subfolder.
 - `scriptState` — never set this: it's a reserved config property where the platform persists the script's `state`, encrypted.
 
 ### Script scope
@@ -238,7 +238,7 @@ The script body runs inside an async function — top-level `await` works. `fetc
 The user supplies a pre-signed JWT (a `ui.json` field mapped via `scriptingVariables`); the script exchanges it for a short-lived access token and caches it in `state` until expiry:
 
 ```javascript
-// dataStreams/scripts/preRequest/my-plugin.js
+// preRequest.js
 const now = Date.now();
 if (typeof state?.token !== "string" || (state?.expiryTime ?? 0) <= now) {
     const authUrl = `${context.dataSources[0].baseUrl.replace(/\/*$/, "")}/api/auth/authenticate`;

--- a/.claude/skills/build-plugin/references/metadata.md
+++ b/.claude/skills/build-plugin/references/metadata.md
@@ -199,8 +199,6 @@ Set exactly one of `jwtSecret` (HMAC algorithms) or `jwtPrivateKey` — a PEM-en
 
 ## Pre-request scripts (custom auth flows)
 
-> Requires WebAPI base plugin **1.8.0+**.
-
 Some APIs have an auth flow no `authMode` above can express — exchanging a long-lived credential for a short-lived access token via an auth endpoint, or signing each request (HMAC canonical-request signatures). For these, set a **pre-request script** in `base.config`: JavaScript that runs immediately before **every** HTTP request the plugin makes (all data streams, including import streams) and can rewrite the request's `url`, `headers`, and `body`.
 
 Exhaust the auth patterns above first — a pre-request script that only sets a static header is just a `headers` entry, and token refresh for OAuth2/JWT Bearer is already automatic.
@@ -224,16 +222,16 @@ In `base.config`:
 
 The script body runs inside an async function — top-level `await` works. `fetch` and `crypto.subtle` are available (for auth calls and HMAC/SHA signing).
 
-| Variable  | Mutable | Notes                                                                                                                                                                                 |
+| Variable  | Mutable | Notes                                                                                                                                                                                  |
 | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url`     | Yes     | [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) instance of the full endpoint address about to be called                                                                  |
-| `method`  | No      | `"get"` or `"post"`                                                                                                                                                                     |
-| `headers` | Yes     | POJO of request headers — the usual thing a script mutates                                                                                                                              |
-| `body`    | Yes     | Request body (POST only)                                                                                                                                                                |
+| `url`     | Yes     | [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) instance of the full endpoint address about to be called                                                                 |
+| `method`  | No      | `"get"` or `"post"`                                                                                                                                                                    |
+| `headers` | Yes     | POJO of request headers — the usual thing a script mutates                                                                                                                             |
+| `body`    | Yes     | Request body (POST only)                                                                                                                                                               |
 | `state`   | Yes     | POJO persisted (encrypted) between requests — cache tokens here with an expiry. It can disappear at any time, so always re-derive when missing or expired, never assume it's populated |
-| `secrets` | No      | Values from `scriptingVariables`, by key                                                                                                                                                |
-| `api`     | No      | `api.report.warning(text)` / `api.report.error(text)`                                                                                                                                   |
-| `context` | No      | `dataSources[0]` (the plugin config, incl. `baseUrl`), `objects`, `timeframe`, `config` (the calling stream's config), `pagingContext`                                                  |
+| `secrets` | No      | Values from `scriptingVariables`, by key                                                                                                                                               |
+| `api`     | No      | `api.report.warning(text)` / `api.report.error(text)`                                                                                                                                  |
+| `context` | No      | `dataSources[0]` (the plugin config, incl. `baseUrl`), `objects`, `timeframe`, `config` (the calling stream's config), `pagingContext`                                                 |
 
 ### Example: token exchange with cached state
 
@@ -246,10 +244,15 @@ if (typeof state?.token !== "string" || (state?.expiryTime ?? 0) <= now) {
     const authUrl = `${context.dataSources[0].baseUrl.replace(/\/*$/, "")}/api/auth/authenticate`;
     const resp = await fetch(authUrl, {
         method: "post",
-        headers: { Accept: "application/json", Authorization: `Bearer ${secrets.signedJwt}` },
+        headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${secrets.signedJwt}`,
+        },
     });
     if (!resp.ok) {
-        api.report.error(`Failed to get token: ${resp.status} - ${resp.statusText}`);
+        api.report.error(
+            `Failed to get token: ${resp.status} - ${resp.statusText}`,
+        );
     }
     const payload = await resp.json();
     state = {


### PR DESCRIPTION
## 📋 Summary

Adds guidance to the `build-plugin` skill for the new `preRequestScript` capability arriving with WebAPI base plugin 1.8.0 (squaredup/squaredup-plugin-repository#1966, [SAAS-8337](https://squaredup-eng.atlassian.net/browse/SAAS-8337)) and its saas-side deploy support, so an agent building a plugin for an API with a custom auth flow (token exchange, per-request HMAC signing) has a supported path.

- New "Pre-request scripts (custom auth flows)" reference section in `references/metadata.md`, co-located with the auth patterns: when to reach for a script (prefer built-in `authMode`s first), wiring via `scriptingVariables` and the `dataStreams/scripts/preRequest/<plugin>.js` file reference, the reserved `scriptState` property, the script's variable scope, and a token-exchange example with `state`-cached expiry drawn from the real N-Able script in the upstream PR.
- Context pointers only elsewhere (single source of truth): Phase 1's auth step in `SKILL.md`, the scaffold file tree, and the post-request-scripts section of `references/data-streams.md`.
- Skill version bumped to 0.0.12.

Note: end-to-end this depends on both upstream PRs shipping — WebAPI 1.8.0 and the saas file-reference inlining.

---

## 🔍 Scope of change

- [x] Documentation only
- [ ] Repository metadata or configuration
- [ ] CI / automation
- [ ] Other (please describe):

---

## 📚 Checklist

- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring pre-request scripts to support custom authentication flows.
  * Documented script inputs, outputs, allowed request modifications, encrypted state persistence, available runtime objects, and scripting variables.
  * Included an end-to-end token exchange example with cached token handling.
  * Clarified that datasource-level scripts run before every request.
  * Updated the documented build-plugin version and scaffold guidance to include optional authentication scripting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->