### PR TITLE
Enforce final newline for json files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,15 +3,12 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = true
 trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.{md,json,js,jsx,ts,tsx}]
 indent_style = space
 indent_size = 4
-
-[*.json]
-insert_final_newline = false
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
<!--
  Use this PR template only for changes that do *not* introduce or a change a plugin.
-->

## 📋 Summary

Every file has value, they all deserve a terminating newline

---

## 🔍 Scope of change

- [ ] Documentation only
- [ ] Repository metadata or configuration
- [ ] CI / automation
- [x] Other (please describe): formatting

---

## 📚 Checklist

- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized file formatting by removing trailing whitespace and ensuring files end with a final newline.
  * Applied consistent formatting rules across supported file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->