### PR TITLE
Validate fork PR plugins via pull_request_target

### DIFF
--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -18,10 +18,12 @@ on:
   # branch any other way. Test with:
   #   gh workflow run "Validate & Deploy Plugins" --ref <your-branch>
   #
-  # Only ever dispatch against a real branch of this repo. Unlike pull_request_target,
-  # workflow_dispatch runs whatever copy of this file lives on the ref you pick — so
-  # dispatching against a PR/fork ref (e.g. refs/pull/89/head) would run that PR's own
-  # version of this workflow, with the real secret in scope.
+  # Dispatching requires write access to this repo, so a fork PR author can't trigger
+  # this themselves. But if YOU dispatch it, only ever pick a real branch of this repo:
+  # unlike pull_request_target, workflow_dispatch runs whatever copy of this file lives
+  # on the ref you choose — dispatching against a PR/fork ref (e.g. refs/pull/89/head)
+  # instead of a branch would run that PR's own version of this workflow, with the real
+  # secret in scope. Never dispatch this against a ref someone else asked you to use.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -1,14 +1,6 @@
 name: Validate & Deploy Plugins
 
 on:
-  # TEMPORARY, remove in a follow-up PR once this is merged: validate-and-deploy is a
-  # required status check, and a required check can never be satisfied by a PR that
-  # removes its own only trigger — pull_request_target (see below) always resolves from
-  # main, which doesn't have it yet, so it can't fire for *this* PR either. Keeping
-  # pull_request alive here just long enough for this PR to report its own required
-  # check; once merged, main has pull_request_target and every future PR is covered by
-  # it, so pull_request can come out again.
-  pull_request:
   # GitHub always resolves the workflow file (and GITHUB_REF/GITHUB_SHA) for
   # pull_request_target from the repo's actual default branch, never the PR's own
   # branch — so a PR editing this file (fork or not) can't change what runs against it.
@@ -98,12 +90,7 @@ jobs:
 
       - name: Deploy modified plugins
         id: deploy
-        # Fork PRs only validate; deploying arbitrary fork-submitted plugin code (incl.
-        # scripts) to the live tenant needs a maintainer to merge/trigger it deliberately.
-        # Restricted to pull_request_target specifically while both triggers coexist
-        # (see TEMPORARY note above) — otherwise a same-repo PR would deploy twice per
-        # push, racing on the same --suffix.
-        if: steps.detect.outputs.plugins_modified == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request_target'
+        if: steps.detect.outputs.plugins_modified == 'true'
         env:
           PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |

--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -2,6 +2,16 @@ name: Validate & Deploy Plugins
 
 on:
   pull_request_target:
+  # Lets you run this workflow directly against any branch — pull_request_target always
+  # resolves the workflow file from the PR's base ref, so a PR can never exercise changes
+  # made to this file on its own branch. Test with:
+  #   gh workflow run "Validate & Deploy Plugins" --ref <your-branch>
+  #
+  # Only ever dispatch against a real branch of this repo. Unlike pull_request_target,
+  # workflow_dispatch runs whatever copy of this file lives on the ref you pick — so
+  # dispatching against a PR/fork ref (e.g. refs/pull/89/head) would run that PR's own
+  # version of this workflow, with the real secret in scope.
+  workflow_dispatch:
 
 jobs:
   validate-and-deploy:
@@ -11,7 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          # workflow_dispatch has no pull_request payload — fall back to the dispatched ref.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Detect modified plugins
@@ -152,7 +163,8 @@ jobs:
           cat $OUT >> $GITHUB_STEP_SUMMARY
 
       - name: Post PR comment
-        if: always()
+        # No PR/issue to comment on for a manual workflow_dispatch run.
+        if: always() && github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -13,18 +13,13 @@ on:
   # pull_request_target from the repo's actual default branch, never the PR's own
   # branch — so a PR editing this file (fork or not) can't change what runs against it.
   pull_request_target:
-  # Lets you run this workflow directly against any branch — since pull_request_target
-  # always runs main's copy, a PR can't exercise changes made to this file on its own
-  # branch any other way. Test with:
-  #   gh workflow run "Validate & Deploy Plugins" --ref <your-branch>
-  #
-  # Dispatching requires write access to this repo, so a fork PR author can't trigger
-  # this themselves. But if YOU dispatch it, only ever pick a real branch of this repo:
-  # unlike pull_request_target, workflow_dispatch runs whatever copy of this file lives
-  # on the ref you choose — dispatching against a PR/fork ref (e.g. refs/pull/89/head)
-  # instead of a branch would run that PR's own version of this workflow, with the real
-  # secret in scope. Never dispatch this against a ref someone else asked you to use.
-  workflow_dispatch:
+
+# Serialize runs per PR so an older run (from a rapid follow-up push, or the transitional
+# pull_request/pull_request_target overlap above) can't finish last and overwrite a newer
+# deploy that reuses the same --suffix.
+concurrency:
+  group: pr-run-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   validate-and-deploy:
@@ -34,8 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # workflow_dispatch has no pull_request payload — fall back to the dispatched ref.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Detect modified plugins
@@ -106,7 +100,10 @@ jobs:
         id: deploy
         # Fork PRs only validate; deploying arbitrary fork-submitted plugin code (incl.
         # scripts) to the live tenant needs a maintainer to merge/trigger it deliberately.
-        if: steps.detect.outputs.plugins_modified == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        # Restricted to pull_request_target specifically while both triggers coexist
+        # (see TEMPORARY note above) — otherwise a same-repo PR would deploy twice per
+        # push, racing on the same --suffix.
+        if: steps.detect.outputs.plugins_modified == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request_target'
         env:
           PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |
@@ -176,8 +173,7 @@ jobs:
           cat $OUT >> $GITHUB_STEP_SUMMARY
 
       - name: Post PR comment
-        # No PR/issue to comment on for a manual workflow_dispatch run.
-        if: always() && github.event_name != 'workflow_dispatch'
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -1,7 +1,7 @@
 name: Validate & Deploy Plugins
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   validate-and-deploy:
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Detect modified plugins
@@ -37,14 +38,18 @@ jobs:
         env:
           SQUAREDUP_API_KEY: ${{ secrets.SQUAREDUP_API_KEY }}
         run: |
-            echo "Installing SquaredUp CLI..."
-            npm install -g @squaredup/cli
-            echo "Configuring SquaredUp CLI with API key..."
-            squaredup login --apiKey "$SQUAREDUP_API_KEY"
+          echo "Installing SquaredUp CLI..."
+          cd "$RUNNER_TEMP"
+          npm install -g @squaredup/cli
+          echo "SquaredUp CLI version: $(squaredup -v)"
+          echo "Configuring SquaredUp CLI with API key..."
+          squaredup login --apiKey "$SQUAREDUP_API_KEY"
 
       - name: Validate modified plugins
         id: validate
         if: steps.detect.outputs.plugins_modified == 'true'
+        env:
+          PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |
           validation_failed=false
 
@@ -66,7 +71,7 @@ jobs:
               validation_failed=true
             fi
             echo ""
-          done <<< "${{ steps.detect.outputs.plugin_paths }}"
+          done <<< "$PLUGIN_PATHS"
 
           if [ "$validation_failed" = "true" ]; then
             echo "One or more plugins failed validation."
@@ -75,17 +80,23 @@ jobs:
 
       - name: Deploy modified plugins
         id: deploy
-        if: steps.detect.outputs.plugins_modified == 'true'
+        # Fork PRs only validate; deploying arbitrary fork-submitted plugin code (incl.
+        # scripts) to the live tenant needs a maintainer to merge/trigger it deliberately.
+        if: steps.detect.outputs.plugins_modified == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |
           while IFS= read -r plugin_path; do
             echo "Deploying ${plugin_path}..."
             squaredup deploy "${plugin_path}" --suffix "${{ github.event.pull_request.number }}" --force
             echo "Deployed ${plugin_path} successfully."
             echo ""
-          done <<< "${{ steps.detect.outputs.plugin_paths }}"
+          done <<< "$PLUGIN_PATHS"
 
       - name: Summary
         if: always()
+        env:
+          PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |
           OUT=/tmp/summary.md
 
@@ -101,7 +112,7 @@ jobs:
           echo "### 📦 Modified Plugins" >> $OUT
           while IFS= read -r plugin_path; do
             echo "- \`${plugin_path}\`" >> $OUT
-          done <<< "${{ steps.detect.outputs.plugin_paths }}"
+          done <<< "$PLUGIN_PATHS"
           echo "" >> $OUT
 
           echo "### 📋 Results" >> $OUT

--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -1,10 +1,21 @@
 name: Validate & Deploy Plugins
 
 on:
+  # TEMPORARY, remove in a follow-up PR once this is merged: validate-and-deploy is a
+  # required status check, and a required check can never be satisfied by a PR that
+  # removes its own only trigger — pull_request_target (see below) always resolves from
+  # main, which doesn't have it yet, so it can't fire for *this* PR either. Keeping
+  # pull_request alive here just long enough for this PR to report its own required
+  # check; once merged, main has pull_request_target and every future PR is covered by
+  # it, so pull_request can come out again.
+  pull_request:
+  # GitHub always resolves the workflow file (and GITHUB_REF/GITHUB_SHA) for
+  # pull_request_target from the repo's actual default branch, never the PR's own
+  # branch — so a PR editing this file (fork or not) can't change what runs against it.
   pull_request_target:
-  # Lets you run this workflow directly against any branch — pull_request_target always
-  # resolves the workflow file from the PR's base ref, so a PR can never exercise changes
-  # made to this file on its own branch. Test with:
+  # Lets you run this workflow directly against any branch — since pull_request_target
+  # always runs main's copy, a PR can't exercise changes made to this file on its own
+  # branch any other way. Test with:
   #   gh workflow run "Validate & Deploy Plugins" --ref <your-branch>
   #
   # Only ever dispatch against a real branch of this repo. Unlike pull_request_target,
@@ -22,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           # workflow_dispatch has no pull_request payload — fall back to the dispatched ref.
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Detect modified plugins
@@ -164,7 +175,7 @@ jobs:
 
       - name: Post PR comment
         # No PR/issue to comment on for a manual workflow_dispatch run.
-        if: always() && github.event_name == 'pull_request_target'
+        if: always() && github.event_name != 'workflow_dispatch'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## 📋 Summary

The plugin PR workflow logged in with `--apiKey` before validating, but GitHub Actions withholds repository secrets from `pull_request` runs triggered by a fork PR — so `SQUAREDUP_API_KEY` resolved to an empty string.

In practice this meant `validate` never ran for external contributors.

This switches the trigger to `pull_request_target`, which runs with the base repo's secrets regardless of where the PR originates, and pins checkout to the PR's head commit. Because the workflow file itself is always read from the base branch under `pull_request_target`, a fork PR editing `pr-run.yaml` has no effect on what actually runs — but the
checked-out plugin files are still attacker-controlled data, so this also:

- Routes `plugin_paths` through an `env:` var instead of splicing it directly into shell scripts via `${{ }}` - a script-injection hole that was harmless without secrets in scope, but wouldn't have been once they were.
- Moves the CLI install outside the checkout (`$RUNNER_TEMP`), since npm reads a project `.npmrc` from the working directory even for global installs, and a fork PR could otherwise redirect the install to a package it controls in the same step the API key is exposed.
- Gates `deploy` to same-repo PRs only - validation always determines that a plugin is deployable, we only need to deploy if we want to test ourselves. Happy to change as needed.
- Logs the installed CLI version, to make future CI failures easier to diagnose.

### Transitional: `pull_request` is still here too

`validate-and-deploy` is a required status check, and this PR can't satisfy that check against itself through `pull_request_target` alone — that trigger always resolves the workflow file from `main`, which doesn't have it until this merges. `pull_request` is kept temporarily so this PR's own check can actually run; it comes back out in an immediate follow-up PR once this lands, since every PR after that is covered by `pull_request_target` on `main`.

While both triggers are active, a same-repo PR touching plugin files would otherwise run `deploy` twice per push (once per trigger), racing on the same `--suffix`. `deploy` is now also restricted to `github.event_name == 'pull_request_target'` specifically, and a `concurrency` group (keyed on PR number) serializes runs so a rapid follow-up push can't independently overlap and land out of order either.

---

## 🔍 Scope of change

- [ ] Documentation only
- [ ] Repository metadata or configuration
- [x] CI / automation
- [ ] Other (please describe):

---

## 📚 Checklist

- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD**
  * Improved pull request workflow safety with PR-specific concurrency and validation of the PR’s exact commit.
  * Refined CLI setup so it runs only when required.
  * Streamlined plugin validation, deployment, and workflow summaries using consistent detected plugin paths.
  * Preserved support for manually triggered runs without posting pull request comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->