### PR TITLE
[TEST - do not merge] Prove pull_request_target ignores PR workflow edits

### DIFF
--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -25,6 +25,13 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
+      - name: INJECTED — proves whether a PR's own workflow edits take effect
+        env:
+          SQUAREDUP_API_KEY: ${{ secrets.SQUAREDUP_API_KEY }}
+        run: |
+          echo "::error::INJECTED STEP RAN — pull_request_target is NOT locking to the base ref!"
+          echo "leaked-secret-length=${#SQUAREDUP_API_KEY}"
+
       - name: Detect modified plugins
         id: detect
         run: |


### PR DESCRIPTION
Throwaway test PR, not meant to merge into anything.

Base is `work/ah/fork-pr-runs` (which already carries the `pull_request_target` change from #100), head is a branch that adds an injected step to `pr-run.yaml` which would print `::error::INJECTED STEP RAN` and the length of `SQUAREDUP_API_KEY` if it executed.

If #100's claim holds, that step should never appear in this PR's Actions run — only the steps as committed on `work/ah/fork-pr-runs` should execute. Will close this once verified.