### PR TITLE
Revert "Validate fork PR plugins via pull_request_target"

### DIFF
--- a/.github/workflows/pr-run.yaml
+++ b/.github/workflows/pr-run.yaml
@@ -1,17 +1,7 @@
 name: Validate & Deploy Plugins
 
 on:
-  # GitHub always resolves the workflow file (and GITHUB_REF/GITHUB_SHA) for
-  # pull_request_target from the repo's actual default branch, never the PR's own
-  # branch — so a PR editing this file (fork or not) can't change what runs against it.
-  pull_request_target:
-
-# Serialize runs per PR so an older run (from a rapid follow-up push, or the transitional
-# pull_request/pull_request_target overlap above) can't finish last and overwrite a newer
-# deploy that reuses the same --suffix.
-concurrency:
-  group: pr-run-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  pull_request:
 
 jobs:
   validate-and-deploy:
@@ -21,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Detect modified plugins
@@ -48,18 +37,14 @@ jobs:
         env:
           SQUAREDUP_API_KEY: ${{ secrets.SQUAREDUP_API_KEY }}
         run: |
-          echo "Installing SquaredUp CLI..."
-          cd "$RUNNER_TEMP"
-          npm install -g @squaredup/cli
-          echo "SquaredUp CLI version: $(squaredup -v)"
-          echo "Configuring SquaredUp CLI with API key..."
-          squaredup login --apiKey "$SQUAREDUP_API_KEY"
+            echo "Installing SquaredUp CLI..."
+            npm install -g @squaredup/cli
+            echo "Configuring SquaredUp CLI with API key..."
+            squaredup login --apiKey "$SQUAREDUP_API_KEY"
 
       - name: Validate modified plugins
         id: validate
         if: steps.detect.outputs.plugins_modified == 'true'
-        env:
-          PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |
           validation_failed=false
 
@@ -81,7 +66,7 @@ jobs:
               validation_failed=true
             fi
             echo ""
-          done <<< "$PLUGIN_PATHS"
+          done <<< "${{ steps.detect.outputs.plugin_paths }}"
 
           if [ "$validation_failed" = "true" ]; then
             echo "One or more plugins failed validation."
@@ -91,20 +76,16 @@ jobs:
       - name: Deploy modified plugins
         id: deploy
         if: steps.detect.outputs.plugins_modified == 'true'
-        env:
-          PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |
           while IFS= read -r plugin_path; do
             echo "Deploying ${plugin_path}..."
             squaredup deploy "${plugin_path}" --suffix "${{ github.event.pull_request.number }}" --force
             echo "Deployed ${plugin_path} successfully."
             echo ""
-          done <<< "$PLUGIN_PATHS"
+          done <<< "${{ steps.detect.outputs.plugin_paths }}"
 
       - name: Summary
         if: always()
-        env:
-          PLUGIN_PATHS: ${{ steps.detect.outputs.plugin_paths }}
         run: |
           OUT=/tmp/summary.md
 
@@ -120,7 +101,7 @@ jobs:
           echo "### 📦 Modified Plugins" >> $OUT
           while IFS= read -r plugin_path; do
             echo "- \`${plugin_path}\`" >> $OUT
-          done <<< "$PLUGIN_PATHS"
+          done <<< "${{ steps.detect.outputs.plugin_paths }}"
           echo "" >> $OUT
 
           echo "### 📋 Results" >> $OUT


### PR DESCRIPTION
## Summary
- Reverts #100 (merge commit 92c5929), which switched `pr-run.yaml` from `pull_request` to `pull_request_target`, added a concurrency group, explicit PR-head checkout, and env-var-based template interpolation.
- Restores the workflow to its pre-#100 state.

## Test plan
- [ ] Confirm the reverted workflow runs correctly on a test PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation workflows for more consistent and secure execution.
  * Simplified workflow concurrency and checkout behavior.
  * Improved handling of detected plugin paths during validation, deployment, and result reporting.
  * No changes to exported functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->