### PR TITLE
fix(spotify): PLUG-4710 unbreak searchArtists after Feb 2026 Web API changes

### DIFF
--- a/plugins/Spotify/v1/dataStreams/recentlyPlayed.json
+++ b/plugins/Spotify/v1/dataStreams/recentlyPlayed.json
@@ -3,8 +3,9 @@
     "name": "recentlyPlayed",
     "config": {
         "httpMethod": "get",
-        "pagingConfig_mode": "none",
-        "pagingConfig_offset_base": 1,
+        "paging": {
+            "mode": "none"
+        },
         "expandInnerObjects": true,
         "endpointPath": "/me/player/recently-played",
         "getArgs": [

--- a/plugins/Spotify/v1/dataStreams/searchArtists.json
+++ b/plugins/Spotify/v1/dataStreams/searchArtists.json
@@ -11,6 +11,10 @@
             {
                 "value": "{{q}}",
                 "key": "q"
+            },
+            {
+                "value": "10",
+                "key": "limit"
             }
         ],
         "pathToData": "artists.items",
@@ -18,25 +22,6 @@
         "expandInnerObjects": true
     },
     "metadata": [
-        {
-            "shape": [
-                "number",
-                {
-                    "decimalPlaces": 0
-                }
-            ],
-            "name": "followers.total",
-            "displayName": "Followers"
-        },
-        {
-            "shape": [
-                "number",
-                {
-                    "decimalPlaces": 0
-                }
-            ],
-            "name": "popularity"
-        },
         {
             "pattern": ".*"
         }

--- a/plugins/Spotify/v1/dataStreams/searchTracks.json
+++ b/plugins/Spotify/v1/dataStreams/searchTracks.json
@@ -13,6 +13,11 @@
                 "key": "type",
                 "value": "track",
                 "needsEncryption": false
+            },
+            {
+                "key": "limit",
+                "value": "10",
+                "needsEncryption": false
             }
         ],
         "headers": [],

--- a/plugins/Spotify/v1/dataStreams/topTracks.json
+++ b/plugins/Spotify/v1/dataStreams/topTracks.json
@@ -3,8 +3,18 @@
     "name": "topTracks",
     "config": {
         "httpMethod": "get",
-        "pagingConfig_mode": "nextUrl",
-        "pagingConfig_offset_base": 1,
+        "paging": {
+            "mode": "nextUrl",
+            "pageSize": {
+                "realm": "queryArg",
+                "path": "limit",
+                "value": "50"
+            },
+            "in": {
+                "realm": "payload",
+                "path": "next"
+            }
+        },
         "expandInnerObjects": true,
         "endpointPath": "/me/top/tracks",
         "getArgs": [
@@ -13,11 +23,6 @@
                 "value": "{{time_range}}"
             }
         ],
-        "pagingConfig_pageSize_realm": "queryArg",
-        "pagingConfig_pageSize_path": "limit",
-        "pagingConfig_pageSize_value": "50",
-        "pagingConfig_pagingIn_realm": "payload",
-        "pagingConfig_pagingIn_path": "next",
         "postRequestScript": "topTracks.js",
         "headers": []
     },

--- a/plugins/Spotify/v1/metadata.json
+++ b/plugins/Spotify/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "spotify",
     "displayName": "Spotify",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": {
         "name": "@jame2O",
         "type": "community"


### PR DESCRIPTION
## Problem

Spotify's Feb 2026 Web API overhaul (enforced for all Dev Mode apps since 9 Mar 2026) removed `popularity` and `followers` from artist objects in `/search` responses, and cut the `/search` `limit` parameter from default 20 / max 50 down to default 5 / max 10.

`searchArtists` explicitly mapped `popularity` and `followers.total` as typed, displayed metadata columns, so the stream came back blank/broken. `searchTracks` already had defensive handling for the field removals, but neither stream pinned `limit`.

Fixes PLUG-4710.

## Changes

**The fix**

- `searchArtists.json` — removed the `followers.total` ("Followers") and `popularity` metadata mappings. The `{"pattern": ".*"}` catch-all stays, so tenants on legacy/Extended Quota access that still receive those fields keep seeing them — just untyped, rather than as broken declared columns.
- `searchArtists.json` / `searchTracks.json` — added an explicit `limit=10` getArg so both streams return the new maximum instead of silently falling back to the new default of 5.
- `metadata.json` — 1.0.2 → 1.0.3 (patch: bug fix, no stream removed or renamed).

**Required to deploy at all**

- `recentlyPlayed.json` / `topTracks.json` — migrated the legacy flat `pagingConfig_*` keys to the current nested `paging` schema. Unrelated to PLUG-4710, but the current CLI validator rejects the old keys with 9 errors, so Spotify v1 could not be deployed by anyone until this was fixed. Same-semantics translation; `pagingConfig_offset_base: 1` was dead config under both `none` and `nextUrl` modes and is dropped.

**Deliberately not done**

No post-request script was added to `searchArtists`. The ticket suggested mirroring `searchTracks.js`, but that script exists to strip `available_markets`, which artist objects don't carry — and deleting `popularity`/`followers` in a script would discard data for tenants that legitimately still receive it. Per the plugin authoring guidance, a stream that doesn't need a script should stay on `pathToData` alone.

## Testing

`squaredup validate` passes. Deployed to the Les Bleus dev tenant as v1.0.3 (`plugin-jhEuPXVFu725TekVbcb0`).

- [ ] **Artists** — rows populate; no Followers/Popularity columns; up to 10 results
- [ ] **Tracks** — up to 10 results rather than 5
- [ ] **Recently Played** / **Top Tracks** — paging still behaves
## Follow-up

`defaultContent/trendsTopItems.dash.json` does `ORDER BY popularity DESC` against `topTracks`. Track `popularity` is deprecated under the same Feb 2026 change, so that tile is likely affected too — out of scope here, worth its own ticket.

🤖 Somewhat generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Spotify recently played and top tracks pagination.
  * Spotify top tracks now load up to 50 items per request.
  * Spotify artist and track searches now return up to 10 results per request.
  * Simplified artist metadata to focus on supported information.
* **Chores**
  * Updated the Spotify plugin version to 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->