### PR TITLE
Fix TeamDynamix auth scripting config

### DIFF
--- a/.claude/skills/build-plugin/references/metadata.md
+++ b/.claude/skills/build-plugin/references/metadata.md
@@ -208,12 +208,14 @@ Exhaust the auth patterns above first — a pre-request script that only sets a 
 In `base.config`:
 
 ```json
+"showScripting": true,
 "scriptingVariables": [
     { "key": "signedJwt", "value": "{{signedJwt}}" }
 ],
 "preRequestScript": "preRequest.js"
 ```
 
+- `showScripting` — **required whenever `preRequestScript` is set.** It defaults to `false`, and when it's falsy the platform skips the pre-request script entirely: no error, no warning, and the `Headers` diagnostic just shows the static `headers` from `base.config`. The symptom is a plugin that looks correctly wired but sends unauthenticated requests. In the manual WebAPI data source this is the "Pre-request script" toggle a user ticks; a declarative plugin has no one to tick it, so it must set the flag itself.
 - `scriptingVariables` — key/value secrets the script reads as `secrets.<key>`. Values support `{{fieldName}}` expressions referencing `ui.json` fields, same as `headers`. Values are encrypted at rest.
 - `preRequestScript` — a file reference relative to the plugin's version root (unlike data-stream scripts, which live under `dataStreams/scripts/`): put the script at `<plugin>/v1/preRequest.js`; it's inlined into the config at deploy time. There's only ever one per plugin, so it doesn't need a per-plugin filename or subfolder.
 - `scriptState` — never set this: it's a reserved config property where the platform persists the script's `state`, encrypted.

--- a/plugins/TeamDynamix/v1/metadata.json
+++ b/plugins/TeamDynamix/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "teamdynamix",
     "displayName": "TeamDynamix",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": {
         "name": "@shawn149",
         "type": "community"
@@ -59,6 +59,7 @@
                 }
             ],
             "queryArgs": [],
+            "showScripting": true,
             "scriptingVariables": [
                 {
                     "key": "beid",


### PR DESCRIPTION
## 📋 Summary

This PR fixes a bug where the TeamDynamix plugin never sent an `Authorization` header, so every request to a customer's portal came back 401.

The plugin sets `preRequestScript` to do the BEID / Web Services Key token exchange, but not `showScripting`, which defaults to `false`. When that flag is falsy the WebAPI base plugin discards the script before running it, with no error and no warning, so the plugin looks correctly wired while sending unauthenticated requests. In the manual WebAPI data source `showScripting` is the "Pre-request script" toggle a user ticks, and a declarative plugin has no one to tick it, so it has to set the flag itself. I've set it to `true` and bumped the plugin to 1.0.2.

I've also added the flag to the build-plugin skill's pre-request section, which covered `scriptingVariables` and `preRequestScript` but never mentioned `showScripting`. Anyone following that guidance ends up with the same silent failure.

To verify, run any data stream against a configured TeamDynamix data source (for example Tickets): before this change every request comes back 401, after it the token exchange runs and the stream returns rows. I haven't been able to test against a live portal, so this is verified against how the platform handles `showScripting` rather than end to end, and it's worth a reviewer with portal access confirming before it goes out.

---

## 🧩 Plugin details

- **Plugin name**: TeamDynamix
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [x] Documentation / metadata / logo
  - [ ] Other (please describe):

---

## ⚠️ Breaking changes

Does this PR introduce any breaking changes?

- [x] No
- [ ] Yes (please describe):

---

## 📚 Documentation

- [x] Documentation updated
- [ ] No documentation changes needed

---

## ✅ Checklist

- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled pre-request scripting support for the TeamDynamix WebAPI integration.
  - Added the required scripting visibility setting to ensure configured pre-request scripts run correctly.

- **Documentation**
  - Updated configuration guidance to explain the required scripting setting and behavior when it is disabled.
  - Clarified that static header diagnostics may appear while requests remain unauthenticated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->