### PR TITLE
Fix Veeam x-api-version header sent as [object Object]

### DIFF
--- a/plugins/VeeamBackupReplication/v1/metadata.json
+++ b/plugins/VeeamBackupReplication/v1/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "veeam-backup-replication",
     "displayName": "Veeam Backup & Replication",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": {
         "name": "SquaredUp Labs",
         "type": "labs"
@@ -41,10 +41,16 @@
             "oauth2Scope": "",
             "ignoreCertificateErrors": "{{ignoreCertificateErrors}}",
             "oauth2TokenExtraHeaders": [
-                { "key": "x-api-version", "value": "{{apiVersion}}" }
+                {
+                    "key": "x-api-version",
+                    "value": "{{ typeof apiVersion === 'object' ? apiVersion.value : apiVersion }}"
+                }
             ],
             "headers": [
-                { "key": "x-api-version", "value": "{{apiVersion}}" }
+                {
+                    "key": "x-api-version",
+                    "value": "{{ typeof apiVersion === 'object' ? apiVersion.value : apiVersion }}"
+                }
             ]
         }
     }

--- a/plugins/VeeamBackupReplication/v1/ui.json
+++ b/plugins/VeeamBackupReplication/v1/ui.json
@@ -37,6 +37,7 @@
         "defaultValue": "1.3-rev1",
         "isMulti": false,
         "isClearable": false,
+        "allowCustomValues": false,
         "validation": {
             "required": true
         },


### PR DESCRIPTION
## 📋 Summary

Fixes the `x-api-version` header being sent as the literal string `[object Object]`, which broke the plugin against **Veeam Backup & Replication 12.x**.

The **REST API version** field uses the `autocomplete` control, which stores the whole `{ value, label }` option object rather than the value string. Interpolating that straight into the header produced:

```
x-api-version: [object Object]
```

**Veeam 13 tolerates the invalid value** and falls back to its latest revision, so the plugin appeared to work and this went unnoticed. **Veeam 12 correctly rejects it**, failing the token request before credentials are even considered:

```
[400] {"errorCode":"NotImplemented","message":"Unsupported RESTAPI version.
The following versions are supported: v1.0-rev1, v1.0-rev2, v1.1-rev0,
v1.1-rev1, v1.1-rev2, v1.2-rev0","resourceId":null}
```

The fix resolves the value in the header expression, handling **both** shapes: the object a dropdown selection produces, and the plain string `defaultValue` holds when the field is left untouched.

```
{{ typeof apiVersion === 'object' ? apiVersion.value : apiVersion }}
```

That dual handling also explains the reported symptom — data sources left on the default `1.3-rev1` sent a valid string and worked, while **only v12 setups failed**, because those are precisely the ones where the revision must be changed from the default.

The dropdown, its options, labels, default and help text are unchanged. `allowCustomValues: false` is added so a free-text revision can't be typed in.

> [!NOTE]
> This is a plugin-side workaround for a platform gap: `autocomplete` fields cannot currently yield a plain value string to plugin config (`selectOptionsAs: 'valueString'` isn't exposed to `ui.json`). Other shipped plugins that feed an `autocomplete` value into config are affected by the same issue — worth tracking separately.
>
> Also worth a separate look: the base `WebAPI` plugin discards the token endpoint's response body on failure, surfacing only `failed with status 400`. Veeam had been returning the precise reason above the whole time; capturing that body would have made this a minutes-long diagnosis.

## 🔗 Related issue(s)

PLUG-4730. Raised from a customer support case where v13 worked but v12.3.2 failed with a generic 400.

## 🧩 Plugin details
- **Plugin name**: Veeam Backup & Replication
- **Type of change**:
  - [x] Bug fix
  - [ ] New datastream
  - [ ] Enhancement to existing datastream
  - [ ] Performance improvement
  - [ ] Documentation / metadata / logo
  - [ ] Other (please describe):

## 🧪 Testing

- Deployed to a SquaredUp dev organization and exercised against **two live VBR servers** reachable through a SquaredUp Agent.
- **Verified in Veeam's own REST API service log** (`Svc.VeeamRestAPI.log`) that the header is now correct — this is the definitive before/after:

  **Before (broken):**
  ```
  [POST] request to [/api/oauth2/token] ... x-api-version: [object Object]
  ```
  **After (this fix):**
  ```
  [POST] request to [/api/oauth2/token] ... x-api-version: 1.3-rev1
  ```

- Confirmed with a **non-default** revision selected from the dropdown (the action that previously corrupted the header), and with the field left at its default — both now send a valid revision string.
- Existing data sources, config validation, object import and all four data streams continue to work; `squaredup validate` passes.

## ⚠️ Breaking changes
Does this PR introduce any breaking changes?
- [x] No
- [ ] Yes (please describe):

Existing data sources are unaffected in behaviour — those on the default revision were already sending a valid header. Anyone whose v12 connection was failing should **re-save their data source** after this ships.

## 📚 Documentation
- [ ] Documentation updated
- [x] No documentation changes needed

The README already instructs users to pick the revision matching their server; no user-facing behaviour or option changed.

## ✅ Checklist

- [x] This PR changes a single plugin only
- [x] No secrets or credentials included
- [x] Plugin, datastream and UI naming follow SquaredUp guidelines
- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API version handling for Veeam Backup & Replication authentication and requests.
  - API version settings now work consistently with both direct and structured values.
- **Improvements**
  - Restricted API version selection to predefined options, preventing unsupported custom entries.
  - Updated the plugin metadata to version 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->